### PR TITLE
Update NOTICE Project name

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-# This is the official list of DST-GO copyright holders and authors.
+# This is the official list of Building Technologies - Ontology Central copyright holders and authors.
 #
 # Often employers or academic institutions have ownership over code that is
 # written in certain circumstances, so please do due diligence to ensure that
@@ -24,5 +24,5 @@ Bosch Building Technologies - Bosch Sicherheitssysteme GmbH
     Andreas Mauer <Andreas.Mauer@de.bosch.com>
     Alwar Srinivas Mandyam Bhoolokam <Alwar.Mandyam@de.bosch.com>
     Christian Baranowski <ChristianMartin.Baranowski@bosch.com>
-    Ruben Jubeh <Ruben.Jubeh@bosch.io>
+    Ruben Jubeh <Ruben.Jubeh@bosch.com>
 


### PR DESCRIPTION
Fix some minor issues in the NOTICE file and update the project name to Building Technologies - Ontology Central.

Signed-off-by: Christian Baranowski <ChristianMartin.Baranowski@bosch.com>