### PR TITLE
Changes to DTDL for Haystack compliance and missing properties (Issue #4)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -24,5 +24,6 @@ Bosch Building Technologies - Bosch Sicherheitssysteme GmbH
     Andreas Mauer <Andreas.Mauer@de.bosch.com>
     Alwar Srinivas Mandyam Bhoolokam <Alwar.Mandyam@de.bosch.com>
     Christian Baranowski <ChristianMartin.Baranowski@bosch.com>
+    David Adams <davida@climatec.com>
     Ruben Jubeh <Ruben.Jubeh@bosch.com>
 

--- a/com/bosch/bt/Foundation/2.0.0/src/Core/DigitalTwin.json
+++ b/com/bosch/bt/Foundation/2.0.0/src/Core/DigitalTwin.json
@@ -49,13 +49,6 @@
             "schema": "string"
         },
         {
-            "@type": "Component",
-            "name": "location",
-            "displayName": "Location",
-            "description": "Geographic coordinate as point.",
-            "schema": "dtmi:com:bosch:bt:foundation:core:GeoLocation;2"
-        },
-        {
             "@type": "Property",
             "name": "externalIds",
             "displayName": "External identifiers",

--- a/com/bosch/bt/Foundation/2.0.0/src/Point/DataPoint.json
+++ b/com/bosch/bt/Foundation/2.0.0/src/Point/DataPoint.json
@@ -212,6 +212,51 @@
                     "name": "Delta",
                     "displayName": "Delta",
                     "enumValue": "Delta"
+                },
+                {
+                    "name": "Effective",
+                    "displayName": "Effective",
+                    "enumValue": "Effective"
+                },
+                {
+                    "name": "Occupied",
+                    "displayName": "Occupied",
+                    "enumValue": "Occupied"
+                },
+                {
+                    "name": "Unoccupied",
+                    "displayName": "Unoccupied",
+                    "enumValue": "Unoccupied"
+                },
+                {
+                    "name": "Standby",
+                    "displayName": "Standby",
+                    "enumValue": "Standby"
+                },
+                {
+                    "name": "Maximum",
+                    "displayName": "Maximum",
+                    "enumValue": "Maximum"
+                },
+                {
+                    "name": "Minimum",
+                    "displayName": "Minimum",
+                    "enumValue": "Minimum"
+                },
+                {
+                    "name": "Standby",
+                    "displayName": "Standby",
+                    "enumValue": "Standby"
+                },
+                {
+                    "name": "Heating",
+                    "displayName": "Heating",
+                    "enumValue": "Heating"
+                },
+                {
+                    "name": "Cooling",
+                    "displayName": "Cooling",
+                    "enumValue": "Cooling"
                 }
             ]
         },
@@ -246,6 +291,10 @@
                     "name": "Motion",
                     "enumValue": "Motion",
                     "displayName": "Motion"
+                },{
+                    "name": "Position",
+                    "enumValue": "Position",
+                    "displayName": "Position"
                 },
                 {
                     "name": "Luminance",
@@ -281,6 +330,26 @@
                     "name": "DewpointTemperature",
                     "enumValue": "DewpointTemperature",
                     "displayName": "DewpointTemperature"
+                },
+                {
+                    "name": "WetBulbTemperature",
+                    "enumValue": "WetBulbTemperature",
+                    "displayName": "WetBulbTemperature"
+                },
+                {
+                    "name": "Damper",
+                    "enumValue": "Damper",
+                    "displayName": "Damper"
+                },
+                {
+                    "name": "Cooling",
+                    "enumValue": "Cooling",
+                    "displayName": "Cooling"
+                },
+                {
+                    "name": "Heating",
+                    "enumValue": "Heating",
+                    "displayName": "Heating"
                 },
                 {
                     "name": "Frost",
@@ -341,7 +410,12 @@
                     "name": "Occupancy",
                     "enumValue": "Occupancy",
                     "displayName": "Occupancy"
-                },    
+                },
+                {
+                    "name": "PPM",
+                    "enumValue": "PPM",
+                    "displayName": "PPM"
+                },
                 {
                     "name": "Power",
                     "enumValue": "Power",

--- a/com/bosch/bt/Foundation/2.0.0/src/Space/AreaValue.json
+++ b/com/bosch/bt/Foundation/2.0.0/src/Space/AreaValue.json
@@ -1,0 +1,25 @@
+{
+    "@id": "dtmi:com:bosch:bt:foundation:space:AreaValue;2",
+    "@type": "Interface",
+    "@context": "dtmi:dtdl:context;2",
+    "displayName": "Area Value",
+    "description": "The value of space/building area. Consists of the value of the point and unit defining the value.",
+    "contents": [
+        {
+            "@type": "Property",
+            "name": "value",
+            "displayName": "Value",
+            "description": "Value of the quantity data point.",
+            "writable": true,
+            "schema": "double"
+        },
+        {
+            "@type": "Property",
+            "name": "unit",
+            "displayName": "Unit",
+            "description": "Unit of the value",
+            "writable": true,
+            "schema": "string"
+        }
+    ]
+}

--- a/com/bosch/bt/Foundation/2.0.0/src/Space/Building.json
+++ b/com/bosch/bt/Foundation/2.0.0/src/Space/Building.json
@@ -4,7 +4,99 @@
     "@context": "dtmi:dtdl:context;2",
     "displayName": "Building",
     "description": "An independent unit of the built environment with a characteristic spatial structure, intended to serve at least one function or user activity.",
-    "extends": "dtmi:com:bosch:bt:foundation:space:Zone;2",
+    "extends": [
+        "dtmi:com:bosch:bt:foundation:core:AbstractTwin;2",
+        "dtmi:com:bosch:bt:foundation:core:DigitalTwin;2"
+    ],
+    "schemas": [
+        {
+            "@id": "dtmi:com:bosch:bt:foundation:space:BuildingTypes;2",
+            "@type": "Enum",
+            "valueSchema": "string",
+            "enumValues": [
+                {
+                    "name": "DataCenter",
+                    "displayName": "Data Center",
+                    "enumValue": "DataCenter"
+                },
+                {
+                    "name": "Hospital",
+                    "displayName": "Hospital",
+                    "enumValue": "Hospital"
+                },
+                {
+                    "name": "Hotel",
+                    "displayName": "Hotel",
+                    "enumValue": "Hotel"
+                },
+                {
+                    "name": "K12School",
+                    "displayName": "K-12 School",
+                    "enumValue": "K12School"
+                },
+                {
+                    "name": "MedicalOffice",
+                    "displayName": "Medical Office",
+                    "enumValue": "MedicalOffice"
+                },
+                {
+                    "name": "MultifamilyHousing",
+                    "displayName": "Multifamily Housing",
+                    "enumValue": "MultifamilyHousing"
+                },
+                {
+                    "name": "Office",
+                    "displayName": "Office",
+                    "enumValue": "Office"
+                },
+                {
+                    "name": "Parking",
+                    "displayName": "Parking",
+                    "enumValue": "Parking"
+                },
+                {
+                    "name": "ResidenceHall",
+                    "displayName": "Residence Hall",
+                    "enumValue": "ResidenceHall"
+                },
+                {
+                    "name": "RetailStore",
+                    "displayName": "RetailStore",
+                    "enumValue": "RetailStore"
+                },
+                {
+                    "name": "SeniorLiving",
+                    "displayName": "Senior Living",
+                    "enumValue": "SeniorLiving"
+                },
+                {
+                    "name": "Supermarket",
+                    "displayName": "Supermarket",
+                    "enumValue": "Supermarket"
+                },
+                {
+                    "name": "SwimmingPool",
+                    "displayName": "Swimming Pool",
+                    "enumValue": "SwimmingPool"
+                },
+                {
+                    "name": "Warehouse",
+                    "displayName": "Warehouse",
+                    "enumValue": "Warehouse"
+                },
+                {
+                    "name": "WastewaterTreatmentPlant",
+                    "displayName": "Wastewater Treatment Plant",
+                    "enumValue": "WastewaterTreatmentPlant"
+                },
+                {
+                    "name": "WorshipFacility",
+                    "displayName": "Worship Facility",
+                    "enumValue": "WorshipFacility"
+                }
+            ]
+        }
+    ],
     "contents": [
         {
             "@type": "Property",
@@ -32,6 +124,14 @@
         },
         {
             "@type": "Property",
+            "name": "postalCode",
+            "displayName": "Postal Code",
+            "description": "The postal code (if applicable).",
+            "writable": true,
+            "schema": "string"
+        },
+        {
+            "@type": "Property",
             "name": "city",
             "displayName": "city",
             "description": "A city of the customer's building (if applicable)",
@@ -45,6 +145,27 @@
             "description": "The address of the site (if applicable).",
             "writable": true,
             "schema": "string"
+        },
+        {
+            "@type": "Component",
+            "name": "location",
+            "displayName": "Location",
+            "description": "Geographic coordinate as point.",
+            "schema": "dtmi:com:bosch:bt:foundation:core:GeoLocation;2"
+        },
+        {
+            "@type": "Property",
+            "name": "type",
+            "displayName": "Type",
+            "description": "Type of the building e.g. Office",
+            "schema": "dtmi:com:bosch:bt:foundation:space:BuildingTypes;2"
+        },
+        {
+            "@type": "Component",
+            "name": "area",
+            "displayName": "Area",
+            "description": "Area of the building",
+            "schema": "dtmi:com:bosch:bt:foundation:space:AreaValue;2"
         },
         {
             "@type": "Relationship",

--- a/com/bosch/bt/Foundation/2.0.0/src/Space/Zone.json
+++ b/com/bosch/bt/Foundation/2.0.0/src/Space/Zone.json
@@ -20,119 +20,19 @@
                     "enumValue": "Atrium"
                 },
                 {
-                    "name": "Hospital",
-                    "displayName": "Hospital",
-                    "enumValue": "Hospital"
-                },
-                {
-                    "name": "School",
-                    "displayName": "School",
-                    "enumValue": "School"
-                },
-                {
-                    "name": "ShoppingMall",
-                    "displayName": "ShoppingMall",
-                    "enumValue": "ShoppingMall"
-                },
-                {
-                    "name": "Stadium",
-                    "displayName": "Stadium",
-                    "enumValue": "Stadium"
-                },
-                {
-                    "name": "VirtualBuilding",
-                    "displayName": "VirtualBuilding",
-                    "enumValue": "VirtualBuilding"
-                },
-                {
-                    "name": "Entrance",
-                    "displayName": "Entrance",
-                    "enumValue": "Entrance"
-                },
-                {
-                    "name": "MainEntrance",
-                    "displayName": "MainEntrance",
-                    "enumValue": "MainEntrance"
-                },
-                {
-                    "name": "ServiceEntrance",
-                    "displayName": "ServiceEntrance",
-                    "enumValue": "ServiceEntrance"
-                },
-                {
-                    "name": "Cafeteria",
-                    "displayName": "Cafeteria",
-                    "enumValue": "Cafeteria"
-                },
-                {
-                    "name": "Cooking",
-                    "displayName": "Cooking",
-                    "enumValue": "Cooking"
-                },
-                {
                     "name": "Bar",
                     "displayName": "Bar",
                     "enumValue": "Bar"
                 },
                 {
-                    "name": "Garage",
-                    "displayName": "Garage",
-                    "enumValue": "Garage"
+                    "name": "BreakRoom",
+                    "displayName": "BreakRoom",
+                    "enumValue": "BreakRoom"
                 },
                 {
-                    "name": "Laboratory",
-                    "displayName": "Laboratory",
-                    "enumValue": "Laboratory"
-                },
-                {
-                    "name": "Office",
-                    "displayName": "Office",
-                    "enumValue": "Office"
-                },
-                {
-                    "name": "PhoneBooth",
-                    "displayName": "PhoneBooth",
-                    "enumValue": "PhoneBooth"
-                },
-                {
-                    "name": "Flexdesk",
-                    "displayName": "Flexdesk",
-                    "enumValue": "Flexdesk"
-                },
-                {
-                    "name": "DisabledToilet",
-                    "displayName": "DisabledToilet",
-                    "enumValue": "DisabledToilet"
-                },
-                {
-                    "name": "Toilet",
-                    "displayName": "Toilet",
-                    "enumValue": "Toilet"
-                },
-                {
-                    "name": "Retail",
-                    "displayName": "Retail",
-                    "enumValue": "Retail"
-                },
-                {
-                    "name": "DataServer",
-                    "displayName": "DataServer",
-                    "enumValue": "DataServer"
-                },
-                {
-                    "name": "Electricity",
-                    "displayName": "Electricity",
-                    "enumValue": "Electricity"
-                },
-                {
-                    "name": "Sprinkler",
-                    "displayName": "Sprinkler",
-                    "enumValue": "Sprinkler"
-                },
-                {
-                    "name": "Utilities",
-                    "displayName": "Utilities",
-                    "enumValue": "Utilities"
+                    "name": "Cafeteria",
+                    "displayName": "Cafeteria",
+                    "enumValue": "Cafeteria"
                 },
                 {
                     "name": "Cleaning",
@@ -145,14 +45,44 @@
                     "enumValue": "Conference"
                 },
                 {
+                    "name": "ConferenceRoom",
+                    "displayName": "ConferenceRoom",
+                    "enumValue": "ConferenceRoom"
+                },
+                {
                     "name": "Conversation",
                     "displayName": "Conversation",
                     "enumValue": "Conversation"
                 },
                 {
-                    "name": "Copying",
+                    "name": "CopyRoom",
                     "displayName": "Copying",
                     "enumValue": "Copying"
+                },
+                {
+                    "name": "ConferenceRoom",
+                    "displayName": "ConferenceRoom",
+                    "enumValue": "ConferenceRoom"
+                },
+                {
+                    "name": "Cooking",
+                    "displayName": "Cooking",
+                    "enumValue": "Cooking"
+                },
+                {
+                    "name": "DataServer",
+                    "displayName": "DataServer",
+                    "enumValue": "DataServer"
+                },
+                {
+                    "name": "DisabledToilet",
+                    "displayName": "DisabledToilet",
+                    "enumValue": "DisabledToilet"
+                },
+                {
+                    "name": "Electricity",
+                    "displayName": "Electricity",
+                    "enumValue": "Electricity"
                 },
                 {
                     "name": "Elevator",
@@ -160,14 +90,94 @@
                     "enumValue": "Elevator"
                 },
                 {
+                    "name": "ElevatorLobby",
+                    "displayName": "ElevatorLobby",
+                    "enumValue": "ElevatorLobby"
+                },
+                {
+                    "name": "Entrance",
+                    "displayName": "Entrance",
+                    "enumValue": "Entrance"
+                },
+                {
+                    "name": "EquipmentRoom",
+                    "displayName": "EquipmentRoom",
+                    "enumValue": "EquipmentRoom"
+                },
+                {
+                    "name": "Flexdesk",
+                    "displayName": "Flexdesk",
+                    "enumValue": "Flexdesk"
+                },
+                {
+                    "name": "Garage",
+                    "displayName": "Garage",
+                    "enumValue": "Garage"
+                },
+                {
+                    "name": "Hallway",
+                    "displayName": "Hallway",
+                    "enumValue": "Hallway"
+                },
+                {
+                    "name": "Hospital",
+                    "displayName": "Hospital",
+                    "enumValue": "Hospital"
+                },
+                {
+                    "name": "Laboratory",
+                    "displayName": "Laboratory",
+                    "enumValue": "Laboratory"
+                },
+                {
                     "name": "Library",
                     "displayName": "Library",
                     "enumValue": "Library"
                 },
                 {
+                    "name": "Lobby",
+                    "displayName": "Lobby",
+                    "enumValue": "Lobby"
+                },
+                {
+                    "name": "LockerRoom",
+                    "displayName": "LockerRoom",
+                    "enumValue": "LockerRoom"
+                },
+                {
+                    "name": "MainEntrance",
+                    "displayName": "MainEntrance",
+                    "enumValue": "MainEntrance"
+                },
+                {
                     "name": "Meditation",
                     "displayName": "Meditation",
                     "enumValue": "Meditation"
+                },
+                {
+                    "name": "Office",
+                    "displayName": "Office",
+                    "enumValue": "Office"
+                },
+                {
+                    "name": "OpenOffice",
+                    "displayName": "OpenOffice",
+                    "enumValue": "OpenOffice"
+                },
+                {
+                    "name": "OperatingRoom",
+                    "displayName": "OperatingRoom",
+                    "enumValue": "OperatingRoom"
+                },
+                {
+                    "name": "PatientRoom",
+                    "displayName": "PatientRoom",
+                    "enumValue": "PatientRoom"
+                },
+                {
+                    "name": "PhoneBooth",
+                    "displayName": "PhoneBooth",
+                    "enumValue": "PhoneBooth"
                 },
                 {
                     "name": "Reception",
@@ -180,6 +190,51 @@
                     "enumValue": "Resting"
                 },
                 {
+                    "name": "Restroom",
+                    "displayName": "Restroom",
+                    "enumValue": "Restroom"
+                },
+                {
+                    "name": "Retail",
+                    "displayName": "Retail",
+                    "enumValue": "Retail"
+                },
+                {
+                    "name": "School",
+                    "displayName": "School",
+                    "enumValue": "School"
+                },
+                {
+                    "name": "ServerRoom",
+                    "displayName": "ServerRoom",
+                    "enumValue": "ServerRoom"
+                },
+                {
+                    "name": "ServiceEntrance",
+                    "displayName": "ServiceEntrance",
+                    "enumValue": "ServiceEntrance"
+                },
+                {
+                    "name": "ShoppingMall",
+                    "displayName": "ShoppingMall",
+                    "enumValue": "ShoppingMall"
+                },
+                {
+                    "name": "Sprinkler",
+                    "displayName": "Sprinkler",
+                    "enumValue": "Sprinkler"
+                },
+                {
+                    "name": "Stadium",
+                    "displayName": "Stadium",
+                    "enumValue": "Stadium"
+                },
+                {
+                    "name": "Staircase",
+                    "displayName": "Staircase",
+                    "enumValue": "Staircase"
+                },
+                {
                     "name": "Stairwell",
                     "displayName": "Stairwell",
                     "enumValue": "Stairwell"
@@ -188,6 +243,11 @@
                     "name": "Staff",
                     "displayName": "Staff",
                     "enumValue": "Staff"
+                },
+                {
+                    "name": "Stairwell",
+                    "displayName": "Stairwell",
+                    "enumValue": "Stairwell"
                 },
                 {
                     "name": "Storage",
@@ -200,6 +260,21 @@
                     "enumValue": "Theater"
                 },
                 {
+                    "name": "Toilet",
+                    "displayName": "Toilet",
+                    "enumValue": "Toilet"
+                },
+                {
+                    "name": "Utilities",
+                    "displayName": "Utilities",
+                    "enumValue": "Utilities"
+                },
+                {
+                    "name": "VirtualBuilding",
+                    "displayName": "VirtualBuilding",
+                    "enumValue": "VirtualBuilding"
+                },
+                {
                     "name": "WasteManagement",
                     "displayName": "WasteManagement",
                     "enumValue": "WasteManagement"
@@ -208,16 +283,6 @@
                     "name": "Workshop",
                     "displayName": "Workshop",
                     "enumValue": "Workshop"
-                },
-                {
-                    "name": "ConferenceRoom",
-                    "displayName": "Conference room",
-                    "enumValue": "ConferenceRoom"
-                },
-                {
-                    "name": "Staircase",
-                    "displayName": "Staircase",
-                    "enumValue": "Staircase"
                 }
             ]
         }

--- a/com/bosch/bt/hvac-systems/2.0.0/src/ThermalDistributor/AirHandlingUnit/AirHandlingUnit.json
+++ b/com/bosch/bt/hvac-systems/2.0.0/src/ThermalDistributor/AirHandlingUnit/AirHandlingUnit.json
@@ -167,6 +167,22 @@
 	"contents": [
 		{
 			"@type": "Property",
+			"name": "HeatingMethod",
+			"displayName": "Heating Method",
+			"description": "The AHU's heating medium for thermal transfer.",
+            "writable": true,
+			"schema": "dtmi:com:bosch:bt:HVAC:AirHandlingUnit:HeatingMethod;2"
+		},
+		{
+			"@type": "Property",
+			"name": "CoolingMethod",
+			"displayName": "Cooling Method",
+			"description": "The AHU's cooling medium for thermal transfer.",
+            "writable": true,
+			"schema": "dtmi:com:bosch:bt:HVAC:AirHandlingUnit:CoolingMethod;2"
+		},
+		{
+			"@type": "Property",
 			"name": "AirVolumeType",
 			"displayName": "Air Volume Type",
 			"description": "The ability of the AHU to adjust the volume of air flow.",

--- a/com/bosch/bt/hvac-systems/2.0.0/src/ThermalDistributor/VariableAirVolume.json
+++ b/com/bosch/bt/hvac-systems/2.0.0/src/ThermalDistributor/VariableAirVolume.json
@@ -93,6 +93,14 @@
 	"contents": [
 		{
 			"@type": "Property",
+			"name": "HeatingAndCoolingMethod",
+			"displayName": "Heating and Cooling Method",
+			"description": "The method for tempering the air used to control space temperature.",
+			"writable": true,
+			"schema": "dtmi:com:bosch:bt:HVAC:VariableAirVolume:HeatingAndCoolingMethod;2"
+		},
+		{
+			"@type": "Property",
 			"name": "AirCircuit",
 			"displayName": "Air Circuit Configuration",
 			"description": "The method used for pulling air using fan from outside the primary airflow.",


### PR DESCRIPTION
**Updated AirHandlingUnit.json**, _Added HeatingMethod and Cooling Method._ Change made to have Haystack equivalent for AHUs.

**Updated VariableAirVolume.json**, _Added Heating and Cooling Method._ Change made to have Haystack equivalent for VAVs.

**Updated [Foundation Space] Zone.json**, _Added Space Types and alphabetized enumValues._ Change made to have 'Space' types to describe spaces rather than having 'Building' types describe spaces.

**Updated Building.json**, _Removed SpaceTypes schemas, added BuildingTypes schemas, Added PostalCode, GeoLocation, BuildingTypes, and Area._ Edits made in conjunction with Zone.json to seprate 'Space' and 'Building' Types.

**Updated DigitalTwin.json**, _Removed location._ This was to prevent the GeoLocation being on every digital twin where it may not apply. Location should be part of the twins which it applies to and not as a global parameter.

**Updated DataPoint.json**, _Added DataPoint:MeasurementTypes, added PointTypes:Types._ Change made to add Haystack equivalent Measurement and Point Types.

**Added AreaValue.json**, _Added to allow area to be used for buildings._ In the future area could be added for spaces, zones, and/or floors. This is up for discussion.

**Updated NOTICE**, _added  David Adams_